### PR TITLE
Fir for problem with Dist::Zilla::File::FromCode

### DIFF
--- a/lib/Dist/Zilla/Plugin/PerlTidy.pm
+++ b/lib/Dist/Zilla/Plugin/PerlTidy.pm
@@ -27,14 +27,14 @@ sub munge_file {
 sub _munge_perl {
     my ( $self, $file ) = @_;
 
-	return if ref($file) eq 'Dist::Zilla::File::FromCode';
     my $source = $file->content;
 
     my $perltidyrc;
     if ( defined $self->perltidyrc ) {
         if ( -r $self->perltidyrc ) {
             $perltidyrc = $self->perltidyrc;
-        } else {
+        }
+        else {
             $self->log_fatal(
                 [ "specified perltidyrc is not readable: %s", $perltidyrc ] );
         }
@@ -51,7 +51,9 @@ sub _munge_perl {
         ( $perltidyrc ? ( perltidyrc => $perltidyrc ) : () ),
     );
 
-    $file->content($destination);
+    ref($file) eq 'Dist::Zilla::File::FromCode'
+      ? $file->code($destination)
+      : $file->content($destination);
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Hi Fay,

I love perltidy, and thus, I love your plugin, so thanks for it, in the first place :-).

I started using dzil a couple of months ago, but then eventually I started using [ReportVersions::Tiny] in my dist.ini, only to find out that it doesn't cope well with your PerlTidy plugin. I stowed this issue in a drawer for a while, but then yesterday I decided to take a look into it.

[PerlTidy] is setting 'content' on the $file argument received, regardless of its specific type (InDisk, InMemory or FromCode). While I agree that we should have a polymorphic interface here, the truth is that Dist::Zilla::File::FromCode does not allow you to set the 'content' attribute. I have no idea why RJBS did that, I have sent him an e-mail asking.

In the meanwhile, I am submitting this patch that will set 'code' if $file is a FromCode, or 'content' otherwise.

I hope you find it useful - I certainly will.

Cheers,
Alexei (RUSSOZ)

Signed-off-by: Alexei Znamensky russoz@cpan.org
