### PR TITLE
Fix to prevent certain Perl files from being skipped

### DIFF
--- a/lib/Dist/Zilla/App/Command/perltidy.pm
+++ b/lib/Dist/Zilla/App/Command/perltidy.pm
@@ -86,6 +86,7 @@ sub execute {
     );
     $rule->file->nonempty;
     $rule->file->not_binary;
+    $rule->file->perl_file;
 
     # $rule->file->line_match(qr/\s\n/);
 
@@ -97,7 +98,6 @@ sub execute {
     );
 
     while ( my $file = $next->() ) {
-        next unless ( $file =~ /\.(t|p[ml])$/ );    # perl file
         my $tidyfile = $file . '.tdy';
         $self->zilla->log_debug( [ 'Tidying %s', $file ] );
         if ( my $pid = fork() ) {

--- a/lib/Dist/Zilla/Plugin/PerlTidy.pm
+++ b/lib/Dist/Zilla/Plugin/PerlTidy.pm
@@ -21,7 +21,7 @@ sub munge_file {
 
     return $self->_munge_perl($file) if $file->name =~ /\.(?:pm|pl|t)$/i;
     return if -B $file->name; # do not try to read binary file
-    return $self->_munge_perl($file) if $file->content =~ /^#!perl(?:$|\s)/;
+    return $self->_munge_perl($file) if $file->content =~ /^#!.*\bperl\b/;
     return;
 }
 


### PR DESCRIPTION
My situation was that I had scripts no extensions. Also the first line of my script contained `#!/usr/bin/perl`.
