### PR TITLE
#8 include nst/nse options to cancel any st/se in perltidyrc

### DIFF
--- a/lib/Dist/Zilla/App/Command/perltidy.pm
+++ b/lib/Dist/Zilla/App/Command/perltidy.pm
@@ -111,6 +111,7 @@ sub execute {
         $tidy->(
             source      => $file,
             destination => $tidyfile,
+            argv        => [qw( -nst -nse )],
             ( $perltidyrc ? ( perltidyrc => $perltidyrc ) : () ),
         );
         exit 0;


### PR DESCRIPTION
Any user with -st/-se options in their default .perltidyrc will be unable to use the plugin without creating a new config.

Passing in -nst/-nse to cancel these options.

See Issue #8

thanks,
Michael